### PR TITLE
Use babel and babel-loader instead of node-jsx and jsx-loader

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
                 module: {
                     loaders: [
                         { test: /\.css$/, loader: 'style!css' },
-                        { test: /\.(js|jsx)$/, exclude: '/node_modules', loader: 'babel-loader' },
+                        { test: /\.(js|jsx)$/, exclude: /node_modules/, loader: 'babel-loader' },
                         { test: /\.json$/, loader: 'json-loader'}
                     ]
                 },

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
                 module: {
                     loaders: [
                         { test: /\.css$/, loader: 'style!css' },
-                        { test: /\.jsx$/, loader: 'jsx-loader' },
+                        { test: /\.(js|jsx)$/, exclude: '/node_modules', loader: 'babel-loader' },
                         { test: /\.json$/, loader: 'json-loader'}
                     ]
                 },

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,7 +18,6 @@
     "fluxible": "^0.2.0",
     "fluxible-plugin-fetchr": "^0.2.1",
     "fluxible-plugin-routr": "^0.3.0",
-    "node-jsx": "^0.12.0",
     "react": "^0.12.0",
     "serialize-javascript": "^1.0.0",
     "serve-favicon": "^2.1.6"
@@ -36,7 +35,6 @@
     "jscs": "^1.9.0",
     "jshint": "^2.5.11",
     "json-loader": "~0.5.1",
-    "jsx-loader": "~0.12.0",
     "nodemon": "^1.2.1",
     "precommit-hook": "^1.0.7",
     "webpack": "^1.4.12",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,6 +7,7 @@
     "lint": "grunt jshint"
   },
   "dependencies": {
+    "babel": "^4.6.3",
     "body-parser": "^1.6.4",
     "cookie-parser": "^1.3.3",
     "csurf": "^1.6.3",
@@ -23,6 +24,7 @@
     "serve-favicon": "^2.1.6"
   },
   "devDependencies": {
+    "babel-loader": "^4.0.0",
     "bundle-loader": "~0.5.0",
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",

--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -7,7 +7,7 @@
  * and the application is rendered via React.
  */
 
-require('node-jsx').install({ extension: '.jsx' });
+require('babel/register');
 
 var express = require('express');
 var serialize = require('serialize-javascript');


### PR DESCRIPTION
Allows ES6 in applications.