### PR TITLE
Set Content-Type in server.js

### DIFF
--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -48,6 +48,7 @@ server.use(function (req, res, next) {
         }));
 
         debug('Sending markup');
+        res.type('html');
         res.write('<!DOCTYPE html>' + html);
         res.end();
     });


### PR DESCRIPTION
Without the `Content-Type: text/html` header, text-based browsers do not render the html.