### PR TITLE
Match jshintrc indent size to editorconfig

### DIFF
--- a/app/templates/_jshintrc
+++ b/app/templates/_jshintrc
@@ -6,7 +6,7 @@
   "curly": true,
   "eqeqeq": true,
   "immed": true,
-  "indent": 2,
+  "indent": 4,
   "latedef": true,
   "newcap": true,
   "noarg": true,


### PR DESCRIPTION
.editorconfig specifies four space indent.