### PR TITLE
Update pageTitle on route change

### DIFF
--- a/app/templates/stores/ApplicationStore.js
+++ b/app/templates/stores/ApplicationStore.js
@@ -24,6 +24,7 @@ var ApplicationStore = createStore({
 
         this.currentPageName = pageName;
         this.currentPage = page;
+        this.pageTitle = page.title;
         this.currentRoute = route;
         this.emitChange();
     },

--- a/app/templates/stores/ApplicationStore.js
+++ b/app/templates/stores/ApplicationStore.js
@@ -12,7 +12,6 @@ var ApplicationStore = createStore({
         this.currentPage = null;
         this.currentRoute = null;
         this.pages = routesConfig;
-        this.pageTitle = '';
     },
     handleNavigate: function (route) {
         if (this.currentRoute && (this.currentRoute.url === route.url)) {
@@ -24,7 +23,6 @@ var ApplicationStore = createStore({
 
         this.currentPageName = pageName;
         this.currentPage = page;
-        this.pageTitle = page.title || '';
         this.currentRoute = route;
         this.emitChange();
     },
@@ -32,7 +30,7 @@ var ApplicationStore = createStore({
         return this.currentPageName;
     },
     getPageTitle: function () {
-        return this.pageTitle;
+        return this.currentPage && this.currentPage.title || '';
     },
     getCurrentRoute: function () {
         return this.currentRoute;
@@ -45,8 +43,7 @@ var ApplicationStore = createStore({
             currentPageName: this.currentPageName,
             currentPage: this.currentPage,
             pages: this.pages,
-            route: this.currentRoute,
-            pageTitle: this.pageTitle
+            route: this.currentRoute
         };
     },
     rehydrate: function (state) {
@@ -54,7 +51,6 @@ var ApplicationStore = createStore({
         this.currentPage = state.currentPage;
         this.pages = state.pages;
         this.currentRoute = state.route;
-        this.pageTitle = state.pageTitle;
     }
 });
 

--- a/app/templates/stores/ApplicationStore.js
+++ b/app/templates/stores/ApplicationStore.js
@@ -24,7 +24,7 @@ var ApplicationStore = createStore({
 
         this.currentPageName = pageName;
         this.currentPage = page;
-        this.pageTitle = page.title;
+        this.pageTitle = page.title || '';
         this.currentRoute = route;
         this.emitChange();
     },


### PR DESCRIPTION
When the route changes, the page title is not updated.

I am not sure this is the best fix, because the loadPage() action dispatches UPDATE_PAGE_TITLE, then the same result can be obtained with an handler for this event.  However this is the shortest fix.