### PR TITLE
Handler for UPDATE_PAGE_TITLE in ApplicationStore.

### DIFF
--- a/app/templates/actions/loadPage.js
+++ b/app/templates/actions/loadPage.js
@@ -2,7 +2,7 @@
 
 module.exports = function loadPage(context, payload, done) {
     context.dispatch('UPDATE_PAGE_TITLE', {
-        pageTitle: payload.config.title
+        pageTitle: payload.config.title || ''
     });
     done();
 };

--- a/app/templates/stores/ApplicationStore.js
+++ b/app/templates/stores/ApplicationStore.js
@@ -5,6 +5,7 @@ var routesConfig = require('../configs/routes');
 var ApplicationStore = createStore({
     storeName: 'ApplicationStore',
     handlers: {
+        'UPDATE_PAGE_TITLE': 'handlePageTitle',
         'CHANGE_ROUTE_SUCCESS': 'handleNavigate'
     },
     initialize: function () {
@@ -13,6 +14,9 @@ var ApplicationStore = createStore({
         this.currentRoute = null;
         this.pages = routesConfig;
         this.pageTitle = '';
+    },
+    handlePageTitle: function (data) {
+        this.pageTitle = data.pageTitle;
     },
     handleNavigate: function (route) {
         if (this.currentRoute && (this.currentRoute.url === route.url)) {


### PR DESCRIPTION
ApplicationStore.pageTitle should be updated when UPDATE_PAGE_TITLE
event is dispatched by loadPage action.

This fixes the same bug as #13, but with an alternative approach.