### PR TITLE
Add .babelrc with es7.classProperties to reduce boilerplate for binding this

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -51,6 +51,7 @@ module.exports = yeoman.generators.Base.extend({
             this.template('_editorconfig', '.editorconfig', this.context);
             this.template('_gitignore', '.gitignore', this.context);
             this.template('_eslintrc', '.eslintrc', this.context);
+            this.template('_babelrc', '.babelrc', this.context);
             if(this.buildSystem === 'grunt'){
                 this.template('_package_grunt.json', 'package.json', this.context);
             } else if (this.buildSystem === 'gulp'){

--- a/app/templates/_babelrc
+++ b/app/templates/_babelrc
@@ -1,0 +1,3 @@
+{
+  "optional": ["es7.classProperties"]
+}

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -24,6 +24,7 @@ describe('fluxible:app', function () {
                 'package.json',
                 'Gruntfile.js',
                 '.editorconfig',
+                '.babelrc',
                 '.eslintrc',
                 'app.js',
                 'components/Application.js'
@@ -45,6 +46,7 @@ describe('fluxible:app', function () {
                 'package.json',
                 'gulpfile.js',
                 '.editorconfig',
+                '.babelrc',
                 '.eslintrc',
                 'app.js',
                 'components/Application.js'


### PR DESCRIPTION
The following pull request adds .babelrc that enables stage 0 ES7 support for class Properties.

Auto-binding in React does not work with ES6 classes, which is are used in this generator. The best workaround I've come across so far is [the one proposed in React docs on autobinding](https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#autobinding). By allowing ES7 class property initializer, we can get rid off verbose constructor this bindings.

I'm open for discussion, but would hope this would be somehow addressed in the generator.