### PR TITLE
chore(server): add body-parser middleware

### DIFF
--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -7,6 +7,7 @@
 
 import express from 'express';
 import compression from 'compression';
+import bodyParser from 'body-parser';
 import path from 'path';
 import serialize from 'serialize-javascript';
 import {navigateAction} from 'fluxible-router';
@@ -23,6 +24,7 @@ const debug = debugLib('<%= name %>');
 const server = express();
 server.use('/public', express.static(path.join(__dirname, '/build')));
 server.use(compression());
+server.use(bodyParser.json());
 
 server.use((req, res, next) => {
     let context = app.createContext();


### PR DESCRIPTION
Fetchr middleware expects that the server uses the body-parser middleware. It will help avoid the errors and issues similar to https://github.com/yahoo/fluxible-plugin-fetchr/issues/46 because the [stack trace](https://github.com/yahoo/fumble/pull/10) still doesn't provide enough information.